### PR TITLE
Correctly install microservicebus-py

### DIFF
--- a/recipes-microservicebus-py/microservicebus-py-service/microservicebus-py-service_0.0.6.bb
+++ b/recipes-microservicebus-py/microservicebus-py-service/microservicebus-py-service_0.0.6.bb
@@ -12,17 +12,17 @@ SYSTEMD_PACKAGES = "${PN}"
 
 SYSTEMD_SERVICE_${PN} = "microservicebus-py.service"
 
-FILES_${PN} += "${systemd_system_unitdir}/microservicebus-py.service"
+FILES_${PN} += "${systemd_system_unitdir}/microservicebus-py.service ${MSB_PY_WORK_DIR}"
 
 #Dynamic parameters for service file, set default values
 MSB_PY_ARG ?= "-w"
 MSB_PY_WORK_DIR ?= "/usr/local/bin/microservicebus-py"
 MSB_PY_USER ?= "msbpy"
-MSB_PY_GROUP ?= "msb"
+MSB_PY_GROUP ?= "msbpy"
 MSB_PY_HOST ?= "microservicebus.com"
 
 do_install() {
-             
+    install -d ${D}/${MSB_PY_WORK_DIR}
     #Replace parameters in service file
     sed -i -e 's:@MSB_PY_WORK_DIR@:${MSB_PY_WORK_DIR}:g' ${WORKDIR}/microservicebus-py.service
     sed -i -e 's:@MSB_PY_USER@:${MSB_PY_USER}:g' ${WORKDIR}/microservicebus-py.service

--- a/recipes-microservicebus-py/microservicebus-py/microservicebus-py_0.0.6.bb
+++ b/recipes-microservicebus-py/microservicebus-py/microservicebus-py_0.0.6.bb
@@ -6,30 +6,6 @@ LIC_FILES_CHKSUM = "file://PKG-INFO;md5=7274cd045f25492b20f765c37bf16016"
 #SRC_URI[md5sum] = "d2edc8bdbd0fa70032215eddd96b508f"
 SRC_URI[sha256sum] = "26bfb332a0b54ca440f19c5f9abc7c5aa2602158ade4558b972bc236e9600eb3"
 
-PYPI_PACKAGE = "microservicebus-py signalrcore"
+PYPI_PACKAGE = "microservicebus-py"
 
 inherit pypi setuptools3
-
-# RDEPENDS_${PN} += " \
-#     python3-psutil \
-#     python3 \
-#     python-pyopenssl \
-#     python3-pip \
-#     python3-misc \
-#     libcurl \
-# "
-# RDEPENDS_${PN} += "	python3 \
-# 					python3-dev \
-# 					python3-pip \
-#                     python-pyopenssl \
-#                     python3-misc \
-# 					python3-urllib3 \
-# 					python3-requests \
-# 					python3-psutil \
-# 					python3-asyncio \
-# 					python3-packaging \
-# 					python3-pydbus \
-# 					python3-pygobject \
-# 					gobject-introspection \
-#                     libcurl \
-# 					"

--- a/recipes-microservicebus-py/microservicebus-py/msgpack_1.0.3.bb
+++ b/recipes-microservicebus-py/microservicebus-py/msgpack_1.0.3.bb
@@ -1,0 +1,9 @@
+SUMMARY = ""
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://PKG-INFO;md5=09539b965ece74ebed63c78771f3a3d4"
+
+SRC_URI[sha256sum] = "51fdc7fb93615286428ee7758cecc2f374d5ff363bdd884c7ea622a7a327a81e"
+
+PYPI_PACKAGE = "msgpack"
+
+inherit pypi setuptools3

--- a/recipes-microservicebus-py/microservicebus-py/signalrcore_0.9.4.bb
+++ b/recipes-microservicebus-py/microservicebus-py/signalrcore_0.9.4.bb
@@ -1,0 +1,9 @@
+SUMMARY = ""
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://PKG-INFO;md5=12c39c44e27e3397e2618a2ec696133a"
+
+SRC_URI[sha256sum] = "59d8a8c421a8526ee4ffe980a19b66dcf4ede8779fe29382b2adc0a8d725ad55"
+
+PYPI_PACKAGE = "signalrcore"
+
+inherit pypi setuptools3

--- a/recipes-microservicebus-py/microservicebus-py/websocket-client_1.3.2.bb
+++ b/recipes-microservicebus-py/microservicebus-py/websocket-client_1.3.2.bb
@@ -1,0 +1,9 @@
+SUMMARY = ""
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://PKG-INFO;md5=f20eb9ecd7d09225af236a2e49416ccc"
+
+SRC_URI[sha256sum] = "50b21db0058f7a953d67cc0445be4b948d7fc196ecbeb8083d68d94628e4abf6"
+
+PYPI_PACKAGE = "websocket-client"
+
+inherit pypi setuptools3

--- a/recipes-microservicebus-py/packagegroups/packagegroup-microservicebus-py.bb
+++ b/recipes-microservicebus-py/packagegroups/packagegroup-microservicebus-py.bb
@@ -1,4 +1,4 @@
-DESCRIPTION = "Apps for development images of the cube"
+DESCRIPTION = "Microservicebus-py packages dependencies"
 LICENCE = "CLOSED"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
@@ -12,6 +12,10 @@ RDEPENDS_${PN} = "	python3 \
 					python3-asyncio \
 					python3-packaging \
 					python3-pydbus \
-					python3-pygobject \
-					gobject-introspection \
+					microservicebus-py \
+					microservicebus-py-service \
+					microservicebus-py-user \
+					signalrcore \
+					websocket-client \
+					msgpack \
 					"


### PR DESCRIPTION
- Changed MSB_PY_GROUP name variable to reflect correct group name
- Changed do_install() to include the WORKDIR the service file is looking for
- Changes to current redundant packages in packagegroup
- Moved signalrcore out of microservicebus-py recipe due to PYPI_PACKAGE var in pypi bbclass not supporting multiple packages
- Added recipes for signalrcore dependencies